### PR TITLE
Prevent scripts from running pre or post install

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ function updatePackageManually(print, lock, latest) {
   )
   fs.writeFileSync(lock.file, lockfileData.content)
 
-  let install = lock.mode === 'yarn' ? 'yarn add -W' : lock.mode + ' install'
+  let install = lock.mode === 'yarn' ? 'yarn add --ignore-scripts -W' : lock.mode + ' install'
   print(
     'Installing new caniuse-lite version\n' +
       pico.yellow('$ ' + install + ' caniuse-lite') +


### PR DESCRIPTION
To aid developers we have a variety of `preinstall` scripts present. These do not work similarly on CI (which is where we run this script). Would it be an option to disable running the scripts on `yarn add` altogether?