### PR TITLE
Detect and preserve npm package-lock.json file indentation

### DIFF
--- a/detect-indent.js
+++ b/detect-indent.js
@@ -1,0 +1,13 @@
+const DEFAULT_INDENT = '  '
+
+function detectIndent(text) {
+  let indentRegexp = /^(\s*)"/m
+  try {
+    let indent = indentRegexp.exec(text)[1]
+    return indent || DEFAULT_INDENT
+  } catch (e) {
+    return DEFAULT_INDENT
+  }
+}
+
+module.exports = detectIndent

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 let childProcess = require('child_process')
-let detectIndent = require('detect-indent')
 let escalade = require('escalade/sync')
 let pico = require('picocolors')
 let path = require('path')
 let fs = require('fs')
+
+let detectIndent = require('./detect-indent')
 
 function BrowserslistUpdateError(message) {
   this.name = 'BrowserslistUpdateError'
@@ -105,7 +106,7 @@ function diffBrowsers(old, current) {
 function updateNpmLockfile(lock, latest) {
   let metadata = { latest, versions: [] }
   let content = deletePackage(JSON.parse(lock.content), metadata)
-  let indent = detectIndent(lock.content).indent || '  '
+  let indent = detectIndent(lock.content)
   metadata.content = JSON.stringify(content, null, indent)
   return metadata
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 let childProcess = require('child_process')
+let detectIndent = require('detect-indent')
 let escalade = require('escalade/sync')
 let pico = require('picocolors')
 let path = require('path')
@@ -104,7 +105,8 @@ function diffBrowsers(old, current) {
 function updateNpmLockfile(lock, latest) {
   let metadata = { latest, versions: [] }
   let content = deletePackage(JSON.parse(lock.content), metadata)
-  metadata.content = JSON.stringify(content, null, '  ')
+  let indent = detectIndent(lock.content).indent || '  '
+  metadata.content = JSON.stringify(content, null, indent)
   return metadata
 }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "unit": "uvu test .test.js"
   },
   "dependencies": {
+    "detect-indent": "^6.1.0",
     "escalade": "^3.1.1",
     "picocolors": "^1.0.0"
   },


### PR DESCRIPTION
I used detect-indent package as it was used for [npm install fix](https://github.com/npm/npm/issues/4718#issuecomment-307142397)