### PR TITLE
pnpm info instead of npm show

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,11 @@ function getLatestInfo(lock) {
       )
     }
   }
+  if (lock.mode === 'pnpm') {
+    return JSON.parse(
+      childProcess.execSync('pnpm info caniuse-lite --json').toString()
+    )
+  }
   return JSON.parse(
     childProcess.execSync('npm show caniuse-lite --json').toString()
   )


### PR DESCRIPTION
Fix browserslist/update-db#12

I tried to run `cli.js` on our `pnpm` repository and it succeeded, so it seems the fix does the job 🙌.

```sh
$ node ../contrib/browserslist-update-db/cli.js 
Latest version:     1.0.30001416
Updating caniuse-lite version
$ pnpm up caniuse-lite
caniuse-lite has been successfully updated

No target browser changes
```

The unit tests succeeded when run on my machine, I'm not sure how to add another one for the new condition though. If you have any advice for that, I'm keen to hear it. You probably already know that but the tests also produced a lot of warnings like the following. It looks like it is a transitive dependency:

```
npm WARN deprecated flatten@1.0.3: flatten is deprecated in favor of utility frameworks such as lodash.
```