### PR TITLE
Clarify bun lockfile detection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ from `caniuse-lite`.
 npx update-browserslist-db@latest
 ```
 
+To override lockfile auto-detection, pass a package manager explicitly:
+
+```sh
+npx update-browserslist-db@latest --package-manager npm
+```
+
+You can also set `UPDATE_BROWSERSLIST_DB_PM=npm`.
+
 Or if using `pnpm`:
 
 ```sh

--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,11 @@ function isArg(arg) {
 function getArgValue(arg) {
   let index = args.indexOf(arg)
   if (index === -1) return
-  return args[index + 1]
+  let value = args[index + 1]
+  if (!value || value.startsWith('-')) {
+    error('Missing value for ' + arg)
+  }
+  return value
 }
 
 function error(msg) {
@@ -35,11 +39,6 @@ function error(msg) {
 }
 
 let packageManager = getArgValue('--package-manager')
-if (isArg('--package-manager')) {
-  if (!packageManager || packageManager.startsWith('-')) {
-    error('Missing value for --package-manager')
-  }
-}
 
 if (isArg('--help') || isArg('-h')) {
   process.stdout.write(getPackage().description + '.\n\n' + USAGE + '\n')

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,10 @@ function getPackage() {
 
 let args = process.argv.slice(2)
 
-let USAGE = 'Usage:\n  npx update-browserslist-db\n'
+let USAGE =
+  'Usage:\n' +
+  '  npx update-browserslist-db\n' +
+  '  npx update-browserslist-db --package-manager npm|yarn|pnpm|bun\n'
 
 function isArg(arg) {
   return args.some(i => i === arg)
@@ -25,13 +28,22 @@ function error(msg) {
   process.exit(1)
 }
 
+let packageManagerIndex = args.indexOf('--package-manager')
+let packageManager
+if (packageManagerIndex !== -1) {
+  packageManager = args[packageManagerIndex + 1]
+  if (!packageManager || packageManager.startsWith('-')) {
+    error('Missing value for --package-manager')
+  }
+}
+
 if (isArg('--help') || isArg('-h')) {
   process.stdout.write(getPackage().description + '.\n\n' + USAGE + '\n')
 } else if (isArg('--version') || isArg('-v')) {
   process.stdout.write('browserslist-lint ' + getPackage().version + '\n')
 } else {
   try {
-    updateDb()
+    updateDb(undefined, { packageManager })
   } catch (e) {
     if (e.name === 'BrowserslistUpdateError') {
       error(e.message)

--- a/cli.js
+++ b/cli.js
@@ -23,15 +23,19 @@ function isArg(arg) {
   return args.some(i => i === arg)
 }
 
+function getArgValue(arg) {
+  let index = args.indexOf(arg)
+  if (index === -1) return
+  return args[index + 1]
+}
+
 function error(msg) {
   process.stderr.write('update-browserslist-db: ' + msg + '\n')
   process.exit(1)
 }
 
-let packageManagerIndex = args.indexOf('--package-manager')
-let packageManager
-if (packageManagerIndex !== -1) {
-  packageManager = args[packageManagerIndex + 1]
+let packageManager = getArgValue('--package-manager')
+if (isArg('--package-manager')) {
   if (!packageManager || packageManager.startsWith('-')) {
     error('Missing value for --package-manager')
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,11 @@
 /**
  * Run update and print output to terminal.
  */
-declare function updateDb(print?: (str: string) => void): void
+declare function updateDb(
+  print?: (str: string) => void,
+  opts?: {
+    packageManager?: 'npm' | 'yarn' | 'pnpm' | 'bun'
+  }
+): void
 
 export = updateDb

--- a/index.js
+++ b/index.js
@@ -8,6 +8,15 @@ const { detectEOL, detectIndent } = require('./utils')
 
 const PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm', 'bun']
 
+function listPackageManagers(packageManagers) {
+  if (packageManagers.length === 1) return packageManagers[0]
+  return (
+    packageManagers.slice(0, -1).join(', ') +
+    ', or ' +
+    packageManagers[packageManagers.length - 1]
+  )
+}
+
 function BrowserslistUpdateError(message) {
   this.name = 'BrowserslistUpdateError'
   this.message = message
@@ -35,30 +44,38 @@ function getPackageManagerOverride(opts) {
   if (packageManager) {
     if (!PACKAGE_MANAGERS.includes(packageManager)) {
       throw new BrowserslistUpdateError(
-        'Package manager must be one of: ' + PACKAGE_MANAGERS.join(', ')
+        'Package manager must be one of: ' +
+          listPackageManagers(PACKAGE_MANAGERS)
       )
     }
     return packageManager
   }
 }
 
-function getLockfile(mode, files) {
-  if (mode === 'pnpm' && existsSync(files.pnpm)) {
-    return { file: files.pnpm, mode: 'pnpm' }
+function getLockfile(mode, packageDir) {
+  let lockfileNpm = join(packageDir, 'package-lock.json')
+  let lockfileShrinkwrap = join(packageDir, 'npm-shrinkwrap.json')
+  let lockfileYarn = join(packageDir, 'yarn.lock')
+  let lockfilePnpm = join(packageDir, 'pnpm-lock.yaml')
+  let lockfileBun = join(packageDir, 'bun.lock')
+  let lockfileBunBinary = join(packageDir, 'bun.lockb')
+
+  if (mode === 'pnpm' && existsSync(lockfilePnpm)) {
+    return { file: lockfilePnpm, mode: 'pnpm' }
   } else if (mode === 'bun') {
-    if (existsSync(files.bun)) {
-      return { file: files.bun, mode: 'bun' }
-    } else if (existsSync(files.bunBinary)) {
-      return { file: files.bunBinary, mode: 'bun' }
+    if (existsSync(lockfileBun)) {
+      return { file: lockfileBun, mode: 'bun' }
+    } else if (existsSync(lockfileBunBinary)) {
+      return { file: lockfileBunBinary, mode: 'bun' }
     }
   } else if (mode === 'npm') {
-    if (existsSync(files.npm)) {
-      return { file: files.npm, mode: 'npm' }
-    } else if (existsSync(files.shrinkwrap)) {
-      return { file: files.shrinkwrap, mode: 'npm' }
+    if (existsSync(lockfileNpm)) {
+      return { file: lockfileNpm, mode: 'npm' }
+    } else if (existsSync(lockfileShrinkwrap)) {
+      return { file: lockfileShrinkwrap, mode: 'npm' }
     }
-  } else if (mode === 'yarn' && existsSync(files.yarn)) {
-    let lock = { file: files.yarn, mode: 'yarn' }
+  } else if (mode === 'yarn' && existsSync(lockfileYarn)) {
+    let lock = { file: lockfileYarn, mode: 'yarn' }
     lock.content = readFileSync(lock.file).toString()
     lock.version = /# yarn lockfile v1/.test(lock.content) ? 1 : 2
     return lock
@@ -77,24 +94,9 @@ function detectLockfile(opts = {}) {
     )
   }
 
-  let lockfileNpm = join(packageDir, 'package-lock.json')
-  let lockfileShrinkwrap = join(packageDir, 'npm-shrinkwrap.json')
-  let lockfileYarn = join(packageDir, 'yarn.lock')
-  let lockfilePnpm = join(packageDir, 'pnpm-lock.yaml')
-  let lockfileBun = join(packageDir, 'bun.lock')
-  let lockfileBunBinary = join(packageDir, 'bun.lockb')
-  let files = {
-    bun: lockfileBun,
-    bunBinary: lockfileBunBinary,
-    npm: lockfileNpm,
-    pnpm: lockfilePnpm,
-    shrinkwrap: lockfileShrinkwrap,
-    yarn: lockfileYarn
-  }
-
   let packageManager = getPackageManagerOverride(opts)
   if (packageManager) {
-    let lock = getLockfile(packageManager, files)
+    let lock = getLockfile(packageManager, packageDir)
     if (lock) return lock
 
     throw new BrowserslistUpdateError(
@@ -102,11 +104,11 @@ function detectLockfile(opts = {}) {
     )
   }
 
-  let detected = ['pnpm', 'bun', 'npm', 'yarn'].find(mode => {
-    return getLockfile(mode, files)
-  })
-  if (detected) {
-    return getLockfile(detected, files)
+  for (let mode of ['pnpm', 'bun', 'npm', 'yarn']) {
+    let lock = getLockfile(mode, packageDir)
+    if (lock) {
+      return lock
+    }
   }
 
   throw new BrowserslistUpdateError(
@@ -135,7 +137,7 @@ function checkPackageManager(lock) {
         'or set `' +
         'UPDATE_BROWSERSLIST_DB_PM' +
         '` to ' +
-        PACKAGE_MANAGERS.filter(i => i !== lock.mode).join(', ') +
+        listPackageManagers(PACKAGE_MANAGERS.filter(i => i !== lock.mode)) +
         '.'
     )
   }
@@ -352,7 +354,9 @@ function updateWith(print, cmd, lock) {
             'or set `' +
             'UPDATE_BROWSERSLIST_DB_PM' +
             '` to ' +
-            PACKAGE_MANAGERS.filter(i => i !== lock.mode).join(', ') +
+            listPackageManagers(
+              PACKAGE_MANAGERS.filter(i => i !== lock.mode)
+            ) +
             '.\n'
         )
       )

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ let pico = require('picocolors')
 
 const { detectEOL, detectIndent } = require('./utils')
 
+const PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm', 'bun']
+
 function BrowserslistUpdateError(message) {
   this.name = 'BrowserslistUpdateError'
   this.message = message
@@ -20,13 +22,50 @@ BrowserslistUpdateError.prototype = Error.prototype
 // Check if HADOOP_HOME is set to determine if this is running in a Hadoop environment
 const IsHadoopExists = !!process.env.HADOOP_HOME
 const yarnCommand = IsHadoopExists ? 'yarnpkg' : 'yarn'
+const packageManagerEnv = 'UPDATE_BROWSERSLIST_DB_PM'
 
 /* c8 ignore next 3 */
 function defaultPrint(str) {
   process.stdout.write(str)
 }
 
-function detectLockfile() {
+function getPackageManagerOverride(opts) {
+  let packageManager = opts.packageManager || process.env[packageManagerEnv]
+
+  if (packageManager) {
+    if (!PACKAGE_MANAGERS.includes(packageManager)) {
+      throw new BrowserslistUpdateError(
+        'Package manager must be one of: ' + PACKAGE_MANAGERS.join(', ')
+      )
+    }
+    return packageManager
+  }
+}
+
+function getLockfile(mode, files) {
+  if (mode === 'pnpm' && existsSync(files.pnpm)) {
+    return { file: files.pnpm, mode: 'pnpm' }
+  } else if (mode === 'bun') {
+    if (existsSync(files.bun)) {
+      return { file: files.bun, mode: 'bun' }
+    } else if (existsSync(files.bunBinary)) {
+      return { file: files.bunBinary, mode: 'bun' }
+    }
+  } else if (mode === 'npm') {
+    if (existsSync(files.npm)) {
+      return { file: files.npm, mode: 'npm' }
+    } else if (existsSync(files.shrinkwrap)) {
+      return { file: files.shrinkwrap, mode: 'npm' }
+    }
+  } else if (mode === 'yarn' && existsSync(files.yarn)) {
+    let lock = { file: files.yarn, mode: 'yarn' }
+    lock.content = readFileSync(lock.file).toString()
+    lock.version = /# yarn lockfile v1/.test(lock.content) ? 1 : 2
+    return lock
+  }
+}
+
+function detectLockfile(opts = {}) {
   let packageDir = escalade('.', (dir, names) => {
     return names.indexOf('package.json') !== -1 ? dir : ''
   })
@@ -44,27 +83,58 @@ function detectLockfile() {
   let lockfilePnpm = join(packageDir, 'pnpm-lock.yaml')
   let lockfileBun = join(packageDir, 'bun.lock')
   let lockfileBunBinary = join(packageDir, 'bun.lockb')
-
-  if (existsSync(lockfilePnpm)) {
-    return { file: lockfilePnpm, mode: 'pnpm' }
-  } else if (existsSync(lockfileBun) || existsSync(lockfileBunBinary)) {
-    return { file: lockfileBun, mode: 'bun' }
-  } else if (existsSync(lockfileNpm)) {
-    return { file: lockfileNpm, mode: 'npm' }
-  } else if (existsSync(lockfileYarn)) {
-    let lock = { file: lockfileYarn, mode: 'yarn' }
-    lock.content = readFileSync(lock.file).toString()
-    lock.version = /# yarn lockfile v1/.test(lock.content) ? 1 : 2
-    return lock
-  } else if (existsSync(lockfileShrinkwrap)) {
-    return { file: lockfileShrinkwrap, mode: 'npm' }
+  let files = {
+    bun: lockfileBun,
+    bunBinary: lockfileBunBinary,
+    npm: lockfileNpm,
+    pnpm: lockfilePnpm,
+    shrinkwrap: lockfileShrinkwrap,
+    yarn: lockfileYarn
   }
+
+  let packageManager = getPackageManagerOverride(opts)
+  if (packageManager) {
+    let lock = getLockfile(packageManager, files)
+    if (lock) return lock
+
+    throw new BrowserslistUpdateError(
+      'No ' + packageManager + ' lockfile found for package manager override'
+    )
+  }
+
+  let detected = ['pnpm', 'bun', 'npm', 'yarn'].find(mode => {
+    return getLockfile(mode, files)
+  })
+  if (detected) {
+    return getLockfile(detected, files)
+  }
+
   throw new BrowserslistUpdateError(
     'No lockfile found. Run "npm install", "yarn install" or "pnpm install"'
   )
 }
 
+function checkPackageManager(lock) {
+  if (lock.mode === 'bun') {
+    try {
+      execSync('bun --version', { stdio: 'ignore' })
+    } catch {
+      throw new BrowserslistUpdateError(
+        'Detected bun lockfile at ' +
+          lock.file +
+          ', but `bun` was not found in PATH.\n' +
+          'Install Bun, remove the Bun lockfile if it is stale, ' +
+          'or set `' +
+          packageManagerEnv +
+          '` to npm, yarn, or pnpm.'
+      )
+    }
+  }
+}
+
 function getLatestInfo(lock) {
+  checkPackageManager(lock)
+
   if (lock.mode === 'yarn') {
     if (lock.version === 1) {
       return JSON.parse(
@@ -256,12 +326,24 @@ function updatePackageManually(print, lock, latest) {
   execSync(del + ' caniuse-lite baseline-browser-mapping')
 }
 
-function updateWith(print, cmd) {
+function updateWith(print, cmd, lock) {
   print('Updating caniuse-lite version\n' + pico.yellow('$ ' + cmd) + '\n')
   try {
     execSync(cmd)
   } catch (e) /* c8 ignore start */ {
     print(pico.red(e.stdout.toString()))
+    if (lock && lock.mode === 'bun') {
+      print(
+        pico.red(
+          '\nDetected bun lockfile at ' +
+            lock.file +
+            '. Install Bun, remove the Bun lockfile if it is stale, ' +
+            'or set `' +
+            packageManagerEnv +
+            '` to npm, yarn, or pnpm.\n'
+        )
+      )
+    }
     print(
       pico.red(
         '\n' +
@@ -277,8 +359,8 @@ function updateWith(print, cmd) {
   } /* c8 ignore end */
 }
 
-module.exports = function updateDB(print = defaultPrint) {
-  let lock = detectLockfile()
+module.exports = function updateDB(print = defaultPrint, opts = {}) {
+  let lock = detectLockfile(opts)
   let latest = getLatestInfo(lock)
 
   let listError
@@ -294,16 +376,17 @@ module.exports = function updateDB(print = defaultPrint) {
   if (lock.mode === 'yarn' && lock.version !== 1) {
     updateWith(
       print,
-      yarnCommand + ' up -R caniuse-lite baseline-browser-mapping'
+      yarnCommand + ' up -R caniuse-lite baseline-browser-mapping',
+      lock
     )
   } else if (lock.mode === 'pnpm') {
     let lockContent = readFileSync(lock.file).toString()
     let packages = lockContent.includes('baseline-browser-mapping')
       ? 'caniuse-lite baseline-browser-mapping'
       : 'caniuse-lite'
-    updateWith(print, 'pnpm up --depth=Infinity --no-save ' + packages)
+    updateWith(print, 'pnpm up --depth=Infinity --no-save ' + packages, lock)
   } else if (lock.mode === 'bun') {
-    updateWith(print, 'bun update caniuse-lite baseline-browser-mapping')
+    updateWith(print, 'bun update caniuse-lite baseline-browser-mapping', lock)
   } else {
     updatePackageManually(print, lock, latest)
   }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ BrowserslistUpdateError.prototype = Error.prototype
 // Check if HADOOP_HOME is set to determine if this is running in a Hadoop environment
 const IsHadoopExists = !!process.env.HADOOP_HOME
 const yarnCommand = IsHadoopExists ? 'yarnpkg' : 'yarn'
-const packageManagerEnv = 'UPDATE_BROWSERSLIST_DB_PM'
 
 /* c8 ignore next 3 */
 function defaultPrint(str) {
@@ -30,7 +29,8 @@ function defaultPrint(str) {
 }
 
 function getPackageManagerOverride(opts) {
-  let packageManager = opts.packageManager || process.env[packageManagerEnv]
+  let packageManager =
+    opts.packageManager || process.env.UPDATE_BROWSERSLIST_DB_PM
 
   if (packageManager) {
     if (!PACKAGE_MANAGERS.includes(packageManager)) {
@@ -115,20 +115,29 @@ function detectLockfile(opts = {}) {
 }
 
 function checkPackageManager(lock) {
-  if (lock.mode === 'bun') {
-    try {
-      execSync('bun --version', { stdio: 'ignore' })
-    } catch {
-      throw new BrowserslistUpdateError(
-        'Detected bun lockfile at ' +
-          lock.file +
-          ', but `bun` was not found in PATH.\n' +
-          'Install Bun, remove the Bun lockfile if it is stale, ' +
-          'or set `' +
-          packageManagerEnv +
-          '` to npm, yarn, or pnpm.'
-      )
-    }
+  let command = lock.mode === 'yarn' ? yarnCommand : lock.mode
+  try {
+    execSync(command + ' --version', { stdio: 'ignore' })
+  } catch {
+    throw new BrowserslistUpdateError(
+      'Detected ' +
+        lock.mode +
+        ' lockfile at ' +
+        lock.file +
+        ', but `' +
+        command +
+        '` was not found in PATH.\n' +
+        'Install ' +
+        lock.mode +
+        ', remove the ' +
+        lock.mode +
+        ' lockfile if it is stale, ' +
+        'or set `' +
+        'UPDATE_BROWSERSLIST_DB_PM' +
+        '` to ' +
+        PACKAGE_MANAGERS.filter(i => i !== lock.mode).join(', ') +
+        '.'
+    )
   }
 }
 
@@ -332,15 +341,19 @@ function updateWith(print, cmd, lock) {
     execSync(cmd)
   } catch (e) /* c8 ignore start */ {
     print(pico.red(e.stdout.toString()))
-    if (lock && lock.mode === 'bun') {
+    if (lock) {
       print(
         pico.red(
-          '\nDetected bun lockfile at ' +
+          '\nDetected ' +
+            lock.mode +
+            ' lockfile at ' +
             lock.file +
-            '. Install Bun, remove the Bun lockfile if it is stale, ' +
+            '. If this lockfile is stale, remove it, ' +
             'or set `' +
-            packageManagerEnv +
-            '` to npm, yarn, or pnpm.\n'
+            'UPDATE_BROWSERSLIST_DB_PM' +
+            '` to ' +
+            PACKAGE_MANAGERS.filter(i => i !== lock.mode).join(', ') +
+            '.\n'
         )
       )
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-let { copy, ensureDir, readFile, remove } = require('fs-extra')
+let { copy, ensureDir, readFile, remove, writeFile } = require('fs-extra')
 let { nanoid } = require('nanoid/non-secure')
 let { execSync } = require('node:child_process')
 let { tmpdir } = require('node:os')
@@ -61,6 +61,39 @@ function runUpdate() {
     out += str.replace(/\x1b\[\d+m/g, '')
   })
   return out
+}
+
+function hidePath(callback) {
+  let paths = {}
+  for (let name of Object.keys(process.env)) {
+    if (name.toLowerCase() === 'path') {
+      paths[name] = process.env[name]
+      delete process.env[name]
+    }
+  }
+  process.env.PATH = ''
+
+  try {
+    callback()
+  } finally {
+    delete process.env.PATH
+    Object.assign(process.env, paths)
+  }
+}
+
+function setEnv(name, value, callback) {
+  let previous = process.env[name]
+  process.env[name] = value
+
+  try {
+    callback()
+  } finally {
+    if (previous === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = previous
+    }
+  }
 }
 
 function checkRunUpdateContents(installedVersions, system) {
@@ -286,6 +319,41 @@ test('updates caniuse-lite for pnpm', async () => {
     lock.includes(`/caniuse-lite/${caniuse.version}:`) ||
       lock.includes(`caniuse-lite@${caniuse.version}:`)
   )
+})
+
+test('throws clear error when detected bun is not available', async () => {
+  let dir = await chdir('update-bun', 'package.json', 'bun.lockb')
+  let error
+
+  hidePath(() => {
+    try {
+      runUpdate()
+    } catch (e) {
+      error = e
+    }
+  })
+
+  ok(error)
+  equal(error.name, 'BrowserslistUpdateError')
+  match(
+    error.message,
+    'Detected bun lockfile at ' +
+      join(dir, 'bun.lockb') +
+      ', but `bun` was not found in PATH.'
+  )
+  match(error.message, 'set `UPDATE_BROWSERSLIST_DB_PM` to npm, yarn, or pnpm')
+})
+
+test('uses package manager override before bun lockfile', async () => {
+  let dir = await chdir('update-npm', 'package.json', 'package-lock.json')
+  await writeFile(join(dir, 'bun.lockb'), '')
+
+  setEnv('UPDATE_BROWSERSLIST_DB_PM', 'npm', () => {
+    checkRunUpdateContents('1.0.30001030', 'npm')
+  })
+
+  let lock = JSON.parse(await readFile(join(dir, 'package-lock.json')))
+  equal(lock.dependencies['caniuse-lite'].version, caniuse.version)
 })
 
 if (bunInstalled) {


### PR DESCRIPTION
Fixes #56.

## What changed

- Detect the actual Bun lockfile path, including `bun.lockb`.
- Add an explicit package manager override through `--package-manager` and `UPDATE_BROWSERSLIST_DB_PM`.
- Show a clearer error when a Bun lockfile selects Bun but `bun` is not available on PATH.
- Document the override and add regression coverage for the Bun error and override path.

## Verification

- `pnpm unit`
- `pnpm test:lint`
- `node cli.js --help`
- `node cli.js --package-manager` exits with the expected missing-value error

Note: `pnpm test` reaches the same passing unit/lint steps locally, but Windows skips the existing Yarn/Bun probes because they redirect to `/dev/null`; CI runs on Ubuntu with Bun installed.