### PR TITLE
Fix caniuse-lite update for Bun

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 let { execSync } = require('child_process')
 let escalade = require('escalade/sync')
 let { existsSync, readFileSync, writeFileSync } = require('fs')
-let { join } = require('path')
+let { dirname, join } = require('path')
 let pico = require('picocolors')
 
 let { detectEOL, detectIndent } = require('./utils')
@@ -264,6 +264,55 @@ function updatePackageManually(print, lock, latest) {
   execSync(del + ' caniuse-lite baseline-browser-mapping')
 }
 
+/**
+ * Bun cannot update a transitive dependency by name: `bun update caniuse-lite`
+ * adds caniuse-lite to package.json as a new direct dependency at the latest
+ * version and leaves every nested copy - the ones that actually get resolved at
+ * runtime - on the old version. A temporary `overrides` entry reaches those,
+ * and the resolutions survive once it is taken back out.
+ */
+function updateBun(print, lock, latest) {
+  let pkgFile = join(dirname(lock.file), 'package.json')
+  let original = readFileSync(pkgFile)
+  let pkg = JSON.parse(original.toString())
+  let withOverride = {
+    ...pkg,
+    overrides: {
+      ...pkg.overrides,
+      'baseline-browser-mapping': 'latest',
+      'caniuse-lite': latest.version
+    }
+  }
+
+  // The file is restored byte for byte below, so its formatting does not matter.
+  writeFileSync(pkgFile, JSON.stringify(withOverride, null, 2) + '\n')
+
+  print(
+    'Updating caniuse-lite version\n' +
+      pico.yellow('$ bun install') +
+      ' (with a temporary caniuse-lite override)\n'
+  )
+  try {
+    execSync('bun install')
+  } catch (e) /* c8 ignore start */ {
+    writeFileSync(pkgFile, original)
+    print(pico.red(e.stdout.toString()))
+    print(
+      pico.red(
+        '\n' +
+          e.stack +
+          '\n\n' +
+          'Problem with `bun install` call. ' +
+          'Run it manually.\n'
+      )
+    )
+    process.exit(1)
+  } /* c8 ignore end */
+
+  writeFileSync(pkgFile, original)
+  updateWith(print, 'bun install', 'Removing the temporary override')
+}
+
 function updateWith(print, cmd, message = 'Updating caniuse-lite version') {
   print(message + '\n' + pico.yellow('$ ' + cmd) + '\n')
   try {
@@ -308,7 +357,7 @@ module.exports = function updateDB(print = defaultPrint) {
       : 'caniuse-lite'
     updateWith(print, 'pnpm up --depth=Infinity --no-save ' + packages)
   } else if (lock.mode === 'bun') {
-    updateWith(print, 'bun update caniuse-lite baseline-browser-mapping')
+    updateBun(print, lock, latest)
   } else if (lock.mode === 'deno') {
     updateWith(print, 'deno add npm:caniuse-lite npm:baseline-browser-mapping')
     updateWith(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -311,19 +311,37 @@ test('updates caniuse-lite for pnpm', async () => {
 
 if (bunInstalled) {
   test('updates caniuse-lite for bun', async () => {
-    await chdir('update-bun', 'package.json', 'bun.lockb')
+    let dir = await chdir('update-bun', 'package.json', 'bun.lockb')
+    let pkgBefore = (await readFile(join(dir, 'package.json'))).toString()
+
     match(
       runUpdate(),
       `Latest version:     ${caniuse.version}\n` +
         'Updating caniuse-lite version\n' +
-        '$ bun update caniuse-lite baseline-browser-mapping\n' +
+        '$ bun install (with a temporary caniuse-lite override)\n' +
+        'Removing the temporary override\n' +
+        '$ bun install\n' +
         'caniuse-lite has been successfully updated\n'
     )
 
     let dependencies = execSync('bun pm ls --all', {
       env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' }
     }).toString()
-    ok(dependencies.includes(`caniuse-lite@${caniuse.version}`))
+    let versions = [...dependencies.matchAll(/caniuse-lite@(\S+)/g)].map(
+      i => i[1]
+    )
+
+    // Every copy has to move, including the nested ones. `bun update
+    // caniuse-lite` only ever added a new hoisted copy at the latest version
+    // and left those behind on the old one.
+    ok(versions.length > 0)
+    equal(
+      versions.filter(i => i !== caniuse.version),
+      []
+    )
+
+    // The override is temporary and must not survive in package.json.
+    equal((await readFile(join(dir, 'package.json'))).toString(), pkgBefore)
   })
 }
 


### PR DESCRIPTION
# Fix `caniuse-lite` update for Bun

## Problem

The Bun branch is a single `updateWith` call:

```js
} else if (lock.mode === 'bun') {
  updateWith(print, 'bun update caniuse-lite baseline-browser-mapping')
```

`bun update <name>` only operates on direct dependencies. `caniuse-lite` is
almost always transitive, so instead of updating it, Bun **adds** it — and
`baseline-browser-mapping` — to `package.json` as new direct dependencies at the
latest version, and leaves every nested copy on the old one.

Two consequences:

1. **`package.json` gains two dependencies the project never asked for**, on
   every run. Every other branch avoids this: `deno` follows `deno add` with
   `deno remove`, `pnpm` passes `--no-save`, and the manual path follows its
   install with `<pm> uninstall`. Only the Bun branch adds without removing.
2. **The stale copies are never updated.** The tool prints
   `caniuse-lite has been successfully updated` while the version that actually
   resolves at runtime is unchanged.

### Reproduction

Using this repository's own `test/fixtures/update-bun` (its lockfile pins
`caniuse-lite@1.0.30001639`), after running the current code:

```bash
$ bun pm ls --all | grep caniuse-lite
│   └── caniuse-lite@1.0.30001639
│   └── caniuse-lite@1.0.30001639
├── caniuse-lite@1.0.30001809     <- newly added direct dependency
│   └── caniuse-lite@1.0.30001639

$ cat package.json   # two dependencies that were not there before
"dependencies": {
  "baseline-browser-mapping": "^2.11.13",
  "caniuse-lite": "^1.0.30001809"
}
```

The three nested copies — the ones Node actually resolves — are untouched. The
existing test passes because it asserts `bun pm ls` *contains* the latest
version, which the newly added hoisted copy satisfies.

### Why not `--no-save`

Bun's `--no-save` is not pnpm's. Bun documents it as "Don't update package.json
**or save a lockfile**", and it behaves that way — with `--no-save`, no lockfile
is written at all, so there is nothing left to update.

## Fix

Apply a temporary `overrides` entry, run `bun install`, then restore
`package.json` byte for byte and install once more. The override reaches nested
copies, and the resolutions survive its removal because the new version still
satisfies the parents' ranges.

Output becomes:

```bash
Latest version:     1.0.30001809
Updating caniuse-lite version
$ bun install (with a temporary caniuse-lite override)
Removing the temporary override
$ bun install
caniuse-lite has been successfully updated
```

`package.json` is restored in the failure path too, so an interrupted install
cannot leave an override behind.

## Test

The existing Bun test is extended to assert what the old code got wrong:

- every `caniuse-lite` in the tree is at the latest version, nested copies
  included — not merely that one of them is;
- `package.json` is byte-identical to the fixture afterwards.

Verified it fails on the current code (`(16 / 17)`, the Bun test failing) and
passes with the change (`30 / 30` across the whole suite). `oxlint` and
Prettier are clean.