### PR TITLE
fix(cli): correct --version package name in cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -28,7 +28,7 @@ function error(msg) {
 if (isArg('--help') || isArg('-h')) {
   process.stdout.write(getPackage().description + '.\n\n' + USAGE + '\n')
 } else if (isArg('--version') || isArg('-v')) {
-  process.stdout.write('browserslist-lint ' + getPackage().version + '\n')
+  process.stdout.write(getPackage().name + ' ' + getPackage().version + '\n')
 } else {
   try {
     updateDb()


### PR DESCRIPTION
### Summary
Fixes an issue where running `npx update-browserslist-db --version` printed `browserslist-lint <version>` instead of `update-browserslist-db <version>`.

### Changes
- Updated `cli.js` to use `getPackage().name` dynamically instead of hardcoded `'browserslist-lint'`.
