### PR TITLE
fix: remove leading space in bun info command

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function getLatestInfo(lock) {
     return JSON.parse(execSync('pnpm info caniuse-lite --json').toString())
   }
   if (lock.mode === 'bun') {
-    return JSON.parse(execSync(' bun info caniuse-lite --json').toString())
+    return JSON.parse(execSync('bun info caniuse-lite --json').toString())
   }
   if (lock.mode === 'deno') {
     let result = JSON.parse(


### PR DESCRIPTION
### Summary
Removes an accidental leading space in the `bun info caniuse-lite --json` command string passed to `execSync()`.

### Problem & Fix
The command string had `' bun info...'` with a leading space, which can cause binary resolution issues in certain environments and shell configurations. Removing the leading space ensures consistent execution across environments.
