### PR TITLE
fix(check-npm-version): sanitize stdout before parsing npm version

### DIFF
--- a/check-npm-version.js
+++ b/check-npm-version.js
@@ -4,7 +4,8 @@ let pico = require('picocolors')
 
 if (!existsSync('deno.lock')) {
   try {
-    let version = parseInt(execSync('npm -v'))
+    let output = execSync('npm -v').toString().trim()
+    let version = parseInt(output.replace(/^[^\d]*/, ''))
     if (version <= 6) {
       process.stderr.write(
         pico.red(


### PR DESCRIPTION
### Summary
Sanitizes the output string of `npm -v` before parsing it as an integer in `check-npm-version.js`.

### Problem & Fix
If tools like Corepack, node deprecation warnings, or environment scripts log non-digit output before printing the npm version string (e.g. `"Corepack is downloading..."`), `parseInt()` evaluates to `NaN`. `NaN <= 6` evaluates to `false`, silently bypassing the version validation check.

Stripping leading non-digit characters ensures accurate version parsing regardless of pre-execution logs.
