### PR TITLE
fix: replace deprecated deno x command with deno run

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function getLatestInfo(lock) {
   }
   if (lock.mode === 'deno') {
     let result = JSON.parse(
-      execSync('deno x -y npm:npm show caniuse-lite version --json').toString()
+      execSync('deno run -A npm:npm show caniuse-lite version --json').toString()
     )
     return { version: Array.isArray(result) ? result[0] : result }
   }


### PR DESCRIPTION
### Summary
Replaces the deprecated `deno x` command with `deno run -A` when fetching `caniuse-lite` package information in Deno environments.

### Problem & Fix
In Deno 2.0+, `deno x` is deprecated/removed in favor of standard `deno run`. Replacing `deno x -y` with `deno run -A` suppresses deprecation warnings and maintains compatibility across both Deno 1.x and Deno 2.x.
